### PR TITLE
feat: Add unit tests for Lambda functions by jules

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,32 @@ Lambda 関数で AWS の What’s New の英語版を取得して日本語に翻
   - feedparser のレイヤーもしくは zip を追加してください
 - scan-dynamodb
   - Android アプリ側で API Gateway 経由で呼び出す DynamoDB のデータ取得用関数
+
+## Lambda 関数のユニットテスト
+
+プロジェクトには、Lambda 関数のためのユニットテストが含まれています。これらのテストは `pytest` を使用して実行できます。
+
+### テストのセットアップ
+
+1.  テストの依存関係をインストールします。リポジトリのルートディレクトリで次のコマンドを実行します（もしくは `lambda` ディレクトリで直接実行しても構いませんが、パスの調整が必要になる場合があります）。
+    ```bash
+    pip install -r lambda/requirements-dev.txt
+    ```
+
+### テストの実行
+
+1.  `lambda` ディレクトリに移動します。
+    ```bash
+    cd lambda
+    ```
+2.  `pytest` を実行します。
+    ```bash
+    pytest
+    ```
+    これにより、`get-whatsnew` および `scan-dynamodb` サブディレクトリ内の `test_*.py` ファイルが自動的に検出され、実行されます。
+
+    テスト実行時に `PYTHONPATH` の設定が必要な場合や、モジュールが見つからないエラーが出る場合は、`lambda` ディレクトリから次のように `PYTHONPATH` を設定して `pytest` を実行してみてください。
+    ```bash
+    PYTHONPATH=. pytest
+    ```
+    これにより、`lambda` ディレクトリ内のモジュール（`get-whatsnew` や `scan-dynamodb` の中の `lumbda_function.py` や `lambda_function.py`）が正しくインポートされるようになります。

--- a/lambda/get-whatsnew/test_lumbda_function.py
+++ b/lambda/get-whatsnew/test_lumbda_function.py
@@ -1,0 +1,192 @@
+import unittest
+from unittest import mock
+import os
+import sys
+from botocore.exceptions import ClientError
+import datetime
+import hashlib
+
+# Add the lambda function's directory to the Python path
+# This allows us to import the lambda_function module
+sys.path.append(os.path.join(os.path.dirname(__file__), '.'))
+
+# Import the functions to be tested
+# Assuming your lambda handler is in 'lumbda_function.py' as per the file listing
+try:
+    import lumbda_function
+except ImportError:
+    # Fallback for local testing if the file name is slightly different or path issues
+    if os.path.exists(os.path.join(os.path.dirname(__file__), 'lumbda_function.py')):
+        from . import lumbda_function
+    else:
+        raise
+
+class TestGetWhatsNewLambda(unittest.TestCase):
+    @mock.patch('lumbda_function.boto3.client')
+    def test_translate_text_success(self, mock_boto_client):
+        # Configure the mock Translate client and its method
+        mock_translate = mock.Mock()
+        mock_translate.translate_text.return_value = {'TranslatedText': 'こんにちは'}
+        mock_boto_client.return_value = mock_translate
+
+        # Call the function
+        result = lumbda_function.translate_text('Hello', 'en', 'ja')
+
+        # Assertions
+        self.assertEqual(result, 'こんにちは')
+        mock_translate.translate_text.assert_called_once_with(
+            Text='Hello', SourceLanguageCode='en', TargetLanguageCode='ja'
+        )
+
+    def test_translate_text_empty_input(self):
+        result = lumbda_function.translate_text('')
+        self.assertEqual(result, '')
+
+    @mock.patch('lumbda_function.boto3.client')
+    def test_translate_text_api_failure(self, mock_boto_client):
+        # Configure the mock to simulate an API error
+        mock_translate = mock.Mock()
+        # Using botocore.exceptions.ClientError for a realistic exception
+        mock_translate.translate_text.side_effect = ClientError(
+            error_response={'Error': {'Code': 'SomeError', 'Message': 'Details'}},
+            operation_name='TranslateText'
+        )
+        mock_boto_client.return_value = mock_translate
+
+        # Call the function
+        original_text = "Hello, world"
+        result = lumbda_function.translate_text(original_text, 'en', 'ja')
+
+        # Assert that the original text is returned on failure
+        self.assertEqual(result, original_text)
+        mock_translate.translate_text.assert_called_once_with(
+            Text=original_text, SourceLanguageCode='en', TargetLanguageCode='ja'
+        )
+
+    # It's good practice to ensure environment variables are set for tests
+    # if the function directly relies on them, though translate_text itself doesn't
+    # directly use os.getenv, the module it's in does.
+    # We can mock them if necessary for other tests.
+    # For now, these tests for translate_text should be fine.
+
+    @mock.patch('lumbda_function.feedparser.parse')
+    @mock.patch('lumbda_function.boto3.resource') # Mock the resource for initial table setup
+    @mock.patch('lumbda_function.table') # Directly mock the global table object used by the function
+    @mock.patch('lumbda_function.translate_text')
+    @mock.patch('lumbda_function.datetime') # Mock datetime to control 'now'
+    def test_fetch_latest_rss(self, mock_datetime_module, mock_translate_text, mock_table_obj, mock_boto_resource, mock_feedparser_parse):
+        # --- Setup Mocks ---
+        # 1. Mock datetime to control 'now'
+        #    The lambda function uses datetime.datetime.utcnow() and datetime.timedelta()
+        #    and datetime.datetime() to parse entry.published_parsed
+        mock_now = datetime.datetime(2023, 10, 27, 0, 0, 0, tzinfo=datetime.timezone.utc)
+        mock_datetime_module.datetime.utcnow.return_value = mock_now
+        mock_datetime_module.timedelta.side_effect = lambda days: datetime.timedelta(days=days)
+        # This is crucial: when the code calls datetime.datetime(*entry.published_parsed[:6]),
+        # we want it to use the standard datetime constructor, not our mock_now.
+        mock_datetime_module.datetime.side_effect = lambda *args, **kwargs: datetime.datetime(*args, **kwargs) if args else mock_now
+
+
+        # 2. Mock feedparser.parse
+        mock_feed_entry_old = mock.Mock()
+        mock_feed_entry_old.link = "http://example.com/old_news"
+        # published_parsed should be a time.struct_time object
+        # UTC: 2023-10-19 00:00:00 (8 days ago from mock_now)
+        mock_feed_entry_old.published_parsed = datetime.datetime(2023, 10, 19, 0, 0, 0, tzinfo=datetime.timezone.utc).timetuple()
+        mock_feed_entry_old.title = "Old News Title"
+        mock_feed_entry_old.description = "Old News Description"
+        mock_feed_entry_old.published = "Thu, 19 Oct 2023 00:00:00 +0000"
+        mock_feed_entry_old.get.side_effect = lambda key, default: {'category': 'Old Category', 'author': 'Old Author'}.get(key, default)
+
+
+        mock_feed_entry_new_exists = mock.Mock()
+        mock_feed_entry_new_exists.link = "http://example.com/new_news_exists"
+        # UTC: 2023-10-26 00:00:00 (1 day ago from mock_now)
+        mock_feed_entry_new_exists.published_parsed = datetime.datetime(2023, 10, 26, 0, 0, 0, tzinfo=datetime.timezone.utc).timetuple()
+        mock_feed_entry_new_exists.title = "New News Title Exists"
+        mock_feed_entry_new_exists.description = "New News Description Exists"
+        mock_feed_entry_new_exists.published = "Wed, 25 Oct 2023 00:00:00 +0000"
+        mock_feed_entry_new_exists.get.side_effect = lambda key, default: {'category': 'New Category', 'author': 'New Author'}.get(key, default)
+
+        mock_feed_entry_new_not_exists = mock.Mock()
+        mock_feed_entry_new_not_exists.link = "http://example.com/new_news_not_exists"
+        # UTC: 2023-10-25 00:00:00 (2 days ago from mock_now)
+        mock_feed_entry_new_not_exists.published_parsed = datetime.datetime(2023, 10, 25, 0, 0, 0, tzinfo=datetime.timezone.utc).timetuple()
+        mock_feed_entry_new_not_exists.title = "New News Title Not Exists"
+        mock_feed_entry_new_not_exists.description = "New News Description Not Exists"
+        mock_feed_entry_new_not_exists.published = "Tue, 24 Oct 2023 00:00:00 +0000"
+        mock_feed_entry_new_not_exists.get.side_effect = lambda key, default: {'category': 'Another Category', 'author': 'Another Author'}.get(key, default)
+
+        mock_feedparser_parse.return_value = mock.Mock(entries=[
+            mock_feed_entry_old,
+            mock_feed_entry_new_exists,
+            mock_feed_entry_new_not_exists
+        ])
+
+        # 3. Mock DynamoDB table (using the mock_table_obj passed by @mock.patch('lumbda_function.table'))
+        #    The lumbda_function.table is already replaced by mock_table_obj by the decorator.
+        def get_item_side_effect(Key):
+            if Key['id'] == hashlib.sha256(mock_feed_entry_new_exists.link.encode()).hexdigest():
+                return {'Item': {'id': 'some_id'}} # Item exists
+            return {} # Item does not exist (empty dict means no 'Item' key)
+        mock_table_obj.get_item.side_effect = get_item_side_effect
+        
+        # We still need to mock boto3.resource('dynamodb').Table('AWS_News') in case it's called during import or elsewhere,
+        # though our primary interaction is via the global 'table' object.
+        # The 'table' object in lumbda_function is initialized at module level.
+        # The @mock.patch('lumbda_function.table', mock_table_obj) handles this for the function's execution.
+        # mock_boto_resource.return_value.Table.return_value = mock_table_obj # This line might be redundant if 'lumbda_function.table' is consistently used.
+
+
+        # 4. Mock translate_text
+        mock_translate_text.side_effect = lambda text, src, dest: f"{text}_ja"
+
+        # --- Call the function ---
+        lumbda_function.fetch_latest_rss()
+
+        # --- Assertions ---
+        # Verify feedparser.parse call
+        mock_feedparser_parse.assert_called_once_with(lumbda_function.RSS_FEED_URL)
+
+        # Verify DynamoDB get_item calls
+        # Called for new_news_exists and new_news_not_exists
+        expected_get_item_calls = [
+            mock.call(Key={'id': hashlib.sha256(mock_feed_entry_new_exists.link.encode()).hexdigest()}),
+            mock.call(Key={'id': hashlib.sha256(mock_feed_entry_new_not_exists.link.encode()).hexdigest()})
+        ]
+        mock_table_obj.get_item.assert_has_calls(expected_get_item_calls, any_order=True)
+        self.assertEqual(mock_table_obj.get_item.call_count, 2)
+
+
+        # Verify translate_text calls (only for the new, non-existing item)
+        mock_translate_text.assert_any_call(mock_feed_entry_new_not_exists.title, 'en', 'ja')
+        mock_translate_text.assert_any_call(mock_feed_entry_new_not_exists.description, 'en', 'ja')
+        self.assertEqual(mock_translate_text.call_count, 2)
+
+
+        # Verify DynamoDB put_item call (only for the new, non-existing item)
+        expected_put_item_arg = {
+            'id': hashlib.sha256(mock_feed_entry_new_not_exists.link.encode()).hexdigest(),
+            'pubdate': mock_feed_entry_new_not_exists.published,
+            'title_en': mock_feed_entry_new_not_exists.title,
+            'title_ja': f"{mock_feed_entry_new_not_exists.title}_ja",
+            'description_en': mock_feed_entry_new_not_exists.description,
+            'description_ja': f"{mock_feed_entry_new_not_exists.description}_ja",
+            'category': 'Another Category', # From mock_feed_entry_new_not_exists.get
+            'author': 'Another Author',   # From mock_feed_entry_new_not_exists.get
+            'link': mock_feed_entry_new_not_exists.link,
+        }
+        mock_table_obj.put_item.assert_called_once_with(Item=expected_put_item_arg)
+
+    @mock.patch('lumbda_function.fetch_latest_rss')
+    def test_lambda_handler(self, mock_fetch_latest_rss):
+        # Call the handler
+        response = lumbda_function.lambda_handler({}, None) # event and context are not used by this handler
+
+        # Assertions
+        mock_fetch_latest_rss.assert_called_once()
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(response['body'], "RSS data fetched and stored successfully.")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lambda/requirements-dev.txt
+++ b/lambda/requirements-dev.txt
@@ -1,0 +1,13 @@
+# Test dependencies
+pytest
+pytest-mock
+boto3
+botocore 
+feedparser # Already a dependency for get-whatsnew, but good to have for local testing if not installed globally
+
+# Specify versions if known or if specific versions are needed, e.g.:
+# pytest>=7.0.0
+# pytest-mock>=3.0.0
+# boto3>=1.20.0
+# botocore>=1.23.0
+# feedparser>=6.0.0

--- a/lambda/scan-dynamodb/test_lambda_function.py
+++ b/lambda/scan-dynamodb/test_lambda_function.py
@@ -1,0 +1,77 @@
+import unittest
+from unittest import mock
+import json
+import os
+import sys
+from botocore.exceptions import ClientError
+
+# Add the lambda function's directory to the Python path
+sys.path.append(os.path.join(os.path.dirname(__file__), '.'))
+
+# Import the function to be tested
+try:
+    import lambda_function # Assuming the file is lambda_function.py
+except ImportError:
+    # Fallback for local testing
+    if os.path.exists(os.path.join(os.path.dirname(__file__), 'lambda_function.py')):
+        from . import lambda_function
+    else:
+        raise
+
+class TestScanDynamoDBLambda(unittest.TestCase):
+    @mock.patch('lambda_function.table') # Mock the global table object
+    def test_lambda_handler_success(self, mock_table_obj):
+        # Configure the mock table and its scan method
+        mock_items = [
+            {'id': '1', 'title': 'Test News 1'},
+            {'id': '2', 'title': 'Test News 2'}
+        ]
+        mock_table_obj.scan.return_value = {'Items': mock_items}
+
+        # Call the handler
+        response = lambda_function.lambda_handler({}, None)
+
+        # Assertions
+        mock_table_obj.scan.assert_called_once()
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(response['headers']['Content-Type'], 'application/json')
+        self.assertEqual(response['headers']['Access-Control-Allow-Origin'], '*')
+        self.assertEqual(json.loads(response['body']), mock_items)
+
+    @mock.patch('lambda_function.table') # Mock the global table object
+    def test_lambda_handler_scan_no_items(self, mock_table_obj):
+        # Configure the mock table for a scan that returns no items
+        mock_table_obj.scan.return_value = {'Items': []} # Or response.get("Items", []) would handle if 'Items' key is missing
+
+        # Call the handler
+        response = lambda_function.lambda_handler({}, None)
+
+        # Assertions
+        mock_table_obj.scan.assert_called_once()
+        self.assertEqual(response['statusCode'], 200)
+        self.assertEqual(json.loads(response['body']), [])
+
+    @mock.patch('lambda_function.table') # Mock the global table object
+    def test_lambda_handler_scan_exception(self, mock_table_obj):
+        # Configure the mock table to raise an exception on scan
+        # from botocore.exceptions import ClientError # Already imported at the top
+        mock_table_obj.scan.side_effect = ClientError(
+            error_response={'Error': {'Code': 'DynamoDBError', 'Message': 'Failed to scan'}},
+            operation_name='Scan'
+        )
+
+        # Call the handler
+        response = lambda_function.lambda_handler({}, None)
+
+        # Assertions
+        mock_table_obj.scan.assert_called_once()
+        self.assertEqual(response['statusCode'], 500)
+        # The exact error message from ClientError can be a bit complex to reconstruct perfectly by hand.
+        # Let's check for the presence of the key parts.
+        response_body = json.loads(response['body'])
+        self.assertTrue('error' in response_body)
+        self.assertTrue('DynamoDBError' in response_body['error']) # Check if the error message contains the error code
+        self.assertTrue('Failed to scan' in response_body['error']) # Check if the error message contains the message
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds unit tests for the `get-whatsnew` and `scan-dynamodb` Lambda functions.

Key changes:
- Created `test_lumbda_function.py` for `get-whatsnew` with tests covering:
    - `translate_text` (success, empty input, API failure)
    - `fetch_latest_rss` (processing old/new/existing items, mocking external services)
    - `lambda_handler`
- Created `test_lambda_function.py` for `scan-dynamodb` with tests covering:
    - `lambda_handler` (success, no items, DynamoDB scan exceptions)
- Added `lambda/requirements-dev.txt` for test dependencies (`pytest`, `pytest-mock`, `boto3`, `botocore`, `feedparser`).
- Updated `README.md` with instructions on how to install test dependencies and run the tests using `pytest`.

These tests improve the robustness and maintainability of the Lambda functions.